### PR TITLE
[FEAT] 인맥관리 리스트 뷰 CoreData 연동

### DIFF
--- a/Dots/Dots/Model/DotsDataContainer.xcdatamodeld/Dots.xcdatamodel/contents
+++ b/Dots/Dots/Model/DotsDataContainer.xcdatamodeld/Dots.xcdatamodel/contents
@@ -24,6 +24,7 @@
         <attribute name="email" optional="YES" attributeType="String"/>
         <attribute name="job" optional="YES" attributeType="String"/>
         <attribute name="linkedIn" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="peopleID" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <relationship name="networkingNotes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="NetworkingNoteEntity" inverseName="relatedPerson" inverseEntity="NetworkingNoteEntity"/>
         <relationship name="strengthSet" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="StrengthEntity" inverseName="networkingPeople" inverseEntity="StrengthEntity"/>

--- a/Dots/Dots/Model/Ex+DotsModel_Create.swift
+++ b/Dots/Dots/Model/Ex+DotsModel_Create.swift
@@ -54,4 +54,17 @@ extension DotsModel {
             entity.ownStrength?.strengthName == name
         })
     }
+    
+    func addNetworking() {
+        let newNetworking = NetworkingPersonEntity(context: manager.context)
+        
+        newNetworking.peopleID = UUID()
+        newNetworking.company = "회사"
+        newNetworking.contanctNum = "010-1111-1111"
+        newNetworking.email = "sffwfe@naver.com"
+        newNetworking.job = "직업2"
+        newNetworking.linkedIn = "링크드인 주소"
+        newNetworking.addToStrengthSet([strength[0], strength[1]])
+        save()
+    }
 }

--- a/Dots/Dots/View/Component/CustomConnectionList.swift
+++ b/Dots/Dots/View/Component/CustomConnectionList.swift
@@ -8,10 +8,8 @@
 import SwiftUI
 
 struct CustomConnectionList: View {
-    var name: String
-    var company: String
-    var job: String
-    var strengths: [String]
+    let entity: NetworkingPersonEntity
+    
     var body: some View {
         RoundedRectangle(cornerRadius: 12)
             .stroke(Color.gray, lineWidth: 0.5)
@@ -21,11 +19,17 @@ struct CustomConnectionList: View {
             .overlay() {
                 VStack(alignment: .leading) {
                     HStack {
-                        Text(name)
+                        Text(entity.name ?? "")
                             .modifier(semiBoldCallout(colorName: Fontcolor.fontBlack.colorName))
-                        Text(company+"・"+job)
-                            .modifier(regularCallout(colorName: Fontcolor.fontBlack.colorName))
-                            .padding(.leading,16)
+                        if let company = entity.company {
+                            Text(company + "・" + entity.job!)
+                                .modifier(regularCallout(colorName: Fontcolor.fontBlack.colorName))
+                                .padding(.leading,16)
+                        } else {
+                            Text(entity.job ?? "")
+                                .modifier(regularCallout(colorName: Fontcolor.fontBlack.colorName))
+                                .padding(.leading,16)
+                        }
                         Spacer()
                     }
                     .padding(.leading,16)
@@ -34,11 +38,13 @@ struct CustomConnectionList: View {
                             .foregroundColor(Color.gray)
                             .padding(.leading,336)
                     }
+                    
                     HStack {
-                        ForEach (strengths.indices,id: \.self) {i in
-                            Text(strengths[i])
-                                .modifier(contactsStrength(colorName: Color.white))
-                            
+                        if let strengthList = entity.strengthSet?.allObjects as? [StrengthEntity] {
+                            ForEach(strengthList) { strength in
+                                Text(strength.strengthName ?? "")
+                                    .modifier(contactsStrength(colorName: Color.white))
+                            }
                         }
                     }
                     .padding(.leading,16)
@@ -46,11 +52,5 @@ struct CustomConnectionList: View {
                 
             }
             .padding(.horizontal,16)
-    }
-}
-
-struct CustomConnectionList_Previews: PreviewProvider {
-    static var previews: some View {
-        CustomConnectionList(name: "신채은", company: "토스", job: "ios 개발", strengths: ["논리적사고", "Core Data"])
     }
 }

--- a/Dots/Dots/View/MainView.swift
+++ b/Dots/Dots/View/MainView.swift
@@ -17,10 +17,10 @@ struct MainView: View {
                 }
             
             SearchConnectionView()
-            .tabItem {
-                Image(systemName: "star.fill")
-                Text("인맥 관리")
-            }
+                .tabItem {
+                    Image(systemName: "star.fill")
+                    Text("인맥 관리")
+                }
         }
     }
 }

--- a/Dots/Dots/View/SearchConnectionView.swift
+++ b/Dots/Dots/View/SearchConnectionView.swift
@@ -8,10 +8,9 @@
 import SwiftUI
 
 struct SearchConnectionView: View {
+    @EnvironmentObject var dotsModel: DotsModel
     @State var name: String = ""
-    var names: [String] = ["신채은","신채은","신채은","신채은"]
-    var companys: [String] = ["토스,LG U+","삼성전자","POSCO","OP.GG","카카오뱅크"]
-    var jobs: [String] = ["ios개발","ios개발","안드로이드 개발","ios 개발","ios 개발","ios개발"]
+    
     var body: some View {
         NavigationStack{
             VStack{
@@ -68,9 +67,8 @@ struct SearchConnectionView: View {
                     }
                     .padding(.horizontal,16)
                 ScrollView{
-                    ForEach(names.indices,id: \.self) {i in
-                        CustomConnectionList(name: names[i], company: companys[i], job: jobs[i], strengths: ["논리적 사고", "Core Data"])
-                        
+                    ForEach(dotsModel.networkingPeople) { person in
+                        CustomConnectionList(entity: person)
                     }
                     .padding(.top,15)
                     


### PR DESCRIPTION
## 🟢 Issue Number
- Resloved: #21 

## 🟢 변경 사항
인맥 관리 리스트 뷰에 CoreData와 연동되어 영구 저장된 데이터를 표시할 수 있습니다.

## 🟢 참고 사항
nil

### ☑️ 작업 유형
- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 리펙토링
- [ ] 문서 업데이트
- [ ] 파일 및 폴더 수정/삭제

### ☑️ 체크리스트
- [x] Merge 하는 브랜치가 올바른가?
- [x] 변경 사항의 동작을 확인하였는가?
